### PR TITLE
Remove the Middle Layer

### DIFF
--- a/Defs/ApparelLayerDefs/ApparelLayerDefs.xml
+++ b/Defs/ApparelLayerDefs/ApparelLayerDefs.xml
@@ -41,15 +41,4 @@
     </modExtensions>
   </ApparelLayerDef>
 
-  <ApparelLayerDef>
-    <defName>MiddleHead</defName>
-    <label>middle (head)</label>
-    <drawOrder>200</drawOrder>
-    <modExtensions>
-      <li Class="CombatExtended.ApparelLayerExtension">
-        <IsHeadwear>true</IsHeadwear>
-      </li>
-    </modExtensions>
-  </ApparelLayerDef>
-  
 </Defs>


### PR DESCRIPTION
## Changes

Removing the middle layer because it is a frankly pointless layer that only breaks rendering.

## Reasoning

It is pretty much a legacy layer that's pretty much only there so pawns can wear tuques under helmets. The Strapped Layer can fill its job better.

